### PR TITLE
[haptics] Port plugin to Qt5 QtFeedback

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,7 @@
-This repository contains a Qt Mobility plugin for the QtFeedback module.
+This repository contains a Qt Mobility plugin for the QtFeedback module
+or a Qt5 QtFeedback plugin, depending on whether it's built with Qt4
+with Mobility support or Qt5 with QtFeedback support.
+
 The plugin provides haptic feedback effects via ff-memless ioctl.
 
 The current maintainer is: Chris Adams (chris.adams@jollamobile.com)

--- a/ffmemless.json
+++ b/ffmemless.json
@@ -1,0 +1,1 @@
+{ "Interfaces": [ "QFeedbackHapticsInterface", "QFeedbackThemeInterface" ] }

--- a/ffmemless.pro
+++ b/ffmemless.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 CONFIG += qt plugin hide_symbols
-QT = core
+QT += core
 TARGET = $$qtLibraryTarget(qtfeedback_ffmemless)
 PLUGIN_TYPE=feedback
 
@@ -15,9 +15,17 @@ settings.path = $$[QT_INSTALL_PLUGINS]/feedback/
 target.path = $$[QT_INSTALL_PLUGINS]/feedback
 INSTALLS += target settings
 
-INCLUDEPATH += . $$[MOBILITY_INCLUDE]
-DEPENDPATH += . $$[MOBILITY_INCLUDE]
-
-CONFIG += mobility
-MOBILITY = feedback
-
+equals(QT_MAJOR_VERSION, 4) {
+    INCLUDEPATH += . $$[MOBILITY_INCLUDE]
+    DEPENDPATH += . $$[MOBILITY_INCLUDE]
+    CONFIG += mobility
+    MOBILITY = feedback
+}
+equals(QT_MAJOR_VERSION, 5) {
+    DEFINES *= USING_QTFEEDBACK
+    OTHER_FILES += ffmemless.json
+    QT += feedback
+    plugindescription.files = ffmemless.json
+    plugindescription.path = $$[QT_INSTALL_PLUGINS]/feedback/
+    INSTALLS += plugindescription
+}

--- a/qfeedback.cpp
+++ b/qfeedback.cpp
@@ -1,9 +1,7 @@
 /****************************************************************************
 **
-** Copyright (C) 2012 Jolla Ltd. (chris.adams@jollamobile.com)
-** Contact: http://www.qt-project.org/legal
-**
-** This file is part of the Qt Mobility Components.
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Chris Adams <chris.adams@jollamobile.com>
 **
 ** $QT_BEGIN_LICENSE:LGPL$
 ** Commercial License Usage
@@ -50,7 +48,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#ifndef USING_QTFEEDBACK
 Q_EXPORT_PLUGIN2(feedback_ffmemless, QFeedbackFFMemless)
+#endif
 
 #define BITS_PER_LONG (sizeof(long) * 8)
 #define OFF(x)  ((x)%BITS_PER_LONG)

--- a/qfeedback.h
+++ b/qfeedback.h
@@ -1,9 +1,7 @@
 /****************************************************************************
 **
-** Copyright (C) 2012 Jolla Ltd. (chris.adams@jollamobile.com)
-** Contact: http://www.qt-project.org/legal
-**
-** This file is part of the Qt Mobility Components.
+** Copyright (C) 2012 Jolla Ltd.
+** Contact: Chris Adams <chris.adams@jollamobile.com>
 **
 ** $QT_BEGIN_LICENSE:LGPL$
 ** Commercial License Usage
@@ -38,23 +36,44 @@
 ** $QT_END_LICENSE$
 **
 ****************************************************************************/
+
 #ifndef QFEEDBACK_FFMEMLESS_H
 #define QFEEDBACK_FFMEMLESS_H
 
+#ifdef USING_QTFEEDBACK
+#include <QtPlugin>
+#else
 #include <qmobilityglobal.h>
+#endif
+
 #include <qfeedbackplugininterfaces.h>
 #include <linux/input.h>
 #include <QElapsedTimer>
 #include <QTimer>
 
 QT_BEGIN_HEADER
+
+#ifdef USING_QTFEEDBACK
+QT_USE_NAMESPACE
+#define ThemeEffect Effect
+#define ThemeBasicKeypad PressWeak
+#define ThemeBasicButton Press
+#define ThemeLongPress PressStrong
+#else
 QTM_USE_NAMESPACE
+#endif
 
 class QFeedbackFFMemless : public QObject, public QFeedbackHapticsInterface, public QFeedbackThemeInterface
 {
     Q_OBJECT
+#ifdef USING_QTFEEDBACK
+    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QtFeedbackPlugin" FILE "ffmemless.json")
+    Q_INTERFACES(QFeedbackHapticsInterface)
+    Q_INTERFACES(QFeedbackThemeInterface)
+#else
     Q_INTERFACES(QTM_NAMESPACE::QFeedbackHapticsInterface)
     Q_INTERFACES(QTM_NAMESPACE::QFeedbackThemeInterface)
+#endif
 public:
     QFeedbackFFMemless(QObject *parent = 0);
     ~QFeedbackFFMemless();

--- a/rpm/qt5-feedback-haptics-ffmemless.spec
+++ b/rpm/qt5-feedback-haptics-ffmemless.spec
@@ -1,0 +1,36 @@
+Name: qt5-feedback-haptics-ffmemless
+Version: 0.0.8
+Release: 1
+Summary: Plugin which provides haptic feedback via ffmemless ioctl
+Group: System/Plugins
+License: LGPLv2.1
+URL: https://github.com/nemomobile/qt-mobility-haptics-ffmemless
+Source0: %{name}-%{version}.tar.bz2
+Requires(post): /sbin/ldconfig
+Requires(postun): /sbin/ldconfig
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt0Feedback)
+Provides: qt-mobility-haptics-ffmemless > 0.0.7
+Obsoletes: qt-mobility-haptics-ffmemless <= 0.0.7
+
+%description
+%{summary}.
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/qt5/plugins/feedback/libqtfeedback_ffmemless.so
+%{_libdir}/qt5/plugins/feedback/ffmemless.json
+%{_libdir}/qt5/plugins/feedback/ffmemless.ini
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+%qmake5
+make
+
+%install
+%qmake5_install
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig


### PR DESCRIPTION
Previously, the plugin only worked as a Qt Mobility plugin.
This commit ensures that it works as a QtFeedback plugin also.
