### PR TITLE
[haptics] Ensure spec version and tag version are the same

### DIFF
--- a/ffmemless.pro
+++ b/ffmemless.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 CONFIG += qt plugin hide_symbols
-QT += core
+QT = core
 TARGET = $$qtLibraryTarget(qtfeedback_ffmemless)
 PLUGIN_TYPE=feedback
 

--- a/rpm/qt5-feedback-haptics-ffmemless.spec
+++ b/rpm/qt5-feedback-haptics-ffmemless.spec
@@ -1,5 +1,5 @@
 Name: qt5-feedback-haptics-ffmemless
-Version: 0.0.8
+Version: 0.1.8
 Release: 1
 Summary: Plugin which provides haptic feedback via ffmemless ioctl
 Group: System/Plugins
@@ -10,8 +10,8 @@ Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt0Feedback)
-Provides: qt-mobility-haptics-ffmemless > 0.0.7
-Obsoletes: qt-mobility-haptics-ffmemless <= 0.0.7
+Provides: qt-mobility-haptics-ffmemless > 0.1.7
+Obsoletes: qt-mobility-haptics-ffmemless <= 0.1.7
 
 %description
 %{summary}.


### PR DESCRIPTION
Previously, the repo was tagged at a much greater version than
the version specified in the spec file.  This commit fixes that
issue by bumping the spec file version.
