### PR TITLE
[haptics] Check profile to determine if vibra is enabled

### DIFF
--- a/ffmemless.pro
+++ b/ffmemless.pro
@@ -28,4 +28,9 @@ equals(QT_MAJOR_VERSION, 5) {
     plugindescription.files = ffmemless.json
     plugindescription.path = $$[QT_INSTALL_PLUGINS]/feedback/
     INSTALLS += plugindescription
+
+    # also enable profile detection. libprofile-qt5 is a bit broken, work around it here.
+    QT += dbus
+    QMAKE_CXXFLAGS += -I/usr/include/profile-qt5
+    QMAKE_LFLAGS += -lprofile-qt5
 }

--- a/qfeedback.h
+++ b/qfeedback.h
@@ -41,6 +41,7 @@
 #define QFEEDBACK_FFMEMLESS_H
 
 #ifdef USING_QTFEEDBACK
+#include <profile.h>
 #include <QtPlugin>
 #else
 #include <qmobilityglobal.h>
@@ -95,6 +96,9 @@ public:
 
 private Q_SLOTS:
     void stateChangeTimerTriggered();
+#ifdef USING_QTFEEDBACK
+    void deviceProfileSettingsChanged();
+#endif
 
 private:
     void stopCustomEffect(QFeedbackHapticsEffect *effect);
@@ -106,6 +110,11 @@ private:
     bool writeEffectEvent(struct input_event *event);
 
 private:
+#ifdef USING_QTFEEDBACK
+    // profile change detection (normal / silent / airplane etc)
+    Profile *m_profile;
+    bool m_profileEnablesVibra;
+#endif
     // theme effects
     struct input_event m_themeEffectPlayEvent;
     struct ff_effect m_themeEffect;

--- a/rpm/qt5-feedback-haptics-ffmemless.spec
+++ b/rpm/qt5-feedback-haptics-ffmemless.spec
@@ -10,6 +10,7 @@ Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt0Feedback)
+BuildRequires:  libprofile-qt5-devel
 Provides: qt-mobility-haptics-ffmemless > 0.1.7
 Obsoletes: qt-mobility-haptics-ffmemless <= 0.1.7
 


### PR DESCRIPTION
This commit adds support for using libprofile-qt to determine whether
the device should have vibra effects enabled or not.
